### PR TITLE
Update de.json

### DIFF
--- a/de.json
+++ b/de.json
@@ -314,7 +314,7 @@
   "departure_time_destination_instructions": "Setzen einer Abfahrtszeit für das Ziel ist nicht möglich",
   "need_to_be_onroute": "Du musst unterwegs sein",
   "share_abrp_link": "Teile ABRP-Link",
-  "share_map_app": "Öffnen in Karte",
+  "share_map_app": "Öffnen in Karten",
   "share_external_app": "Teile in externer App",
   "share_google_link": "Öffnen in Google Maps",
   "calib_ref_cons": "Kalibrierter Referenzverbrauch",


### PR DESCRIPTION
Minor improvement.
Karten is the official german word for the map app from Apple.