### PR TITLE
Update de.json

### DIFF
--- a/de.json
+++ b/de.json
@@ -707,7 +707,7 @@
   "direction_to_name": "nach {{name}}",
   "direction_in_distance": "In {{distance}}",
   "kilometers": "Kilometern",
-  "meters": "Meter",
+  "meters": "Metern",
   "miles": "Meilen",
   "feet": "Fuß",
   "add_a_stop_around_this_waypoint": "Stopp in der Nähe des Wegpunkts hinzufügen",


### PR DESCRIPTION
Incorrect pronunciation discovered:
https://abrp.upvoty.com/b/report-a-bug/error-in-german-voice-directions/

Therefore changed „Meter“ back to „Metern“