### PR TITLE
Updated wrong italian translation for rate charger button

### DIFF
--- a/it.json
+++ b/it.json
@@ -1479,7 +1479,7 @@
   "feedback_results_has_playground_title": "Parco giochi",
   "maybe": "Non so",
   "feedback_help_improve_title": "Aiutateci a migliorare le informazioni sulle colonnine",
-  "feedback_rate_charger_btn": "Tariffa di ricarica",
+  "feedback_rate_charger_btn": "Valuta il caricatore",
   "feedback_report_charger_btn": "Segnalare un problema",
   "rate_a_chager": "Valutare una colonnina",
   "feedback_form_rating_sub_title": "Toccare le stelle per valutare",


### PR DESCRIPTION
In the charging station page, the bottom left button is translated in “Tariffa di ricarica”, while it should be “Valuta il caricatore”.

See: https://abrp.featurebase.app/it/p/wrong-italian-translation/comment/677fa290e1180c14d363c16a